### PR TITLE
INTR-180: downgrade jackson as the plugin bundle only goes up to version 2.17.0

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.hiddenlayer</groupId>
         <artifactId>java-client-parent</artifactId>
-        <version>0.1.12</version>
+        <version>0.1.13</version>
     </parent>
     <artifactId>java-client</artifactId>
     <packaging>jar</packaging>

--- a/generated/pom.xml
+++ b/generated/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.hiddenlayer</groupId>
         <artifactId>java-client-parent</artifactId>
-        <version>0.1.12</version>
+        <version>0.1.13</version>
     </parent>
     <artifactId>hiddenlayer-rest-java</artifactId>
     <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>java-client-parent</artifactId>
     <packaging>pom</packaging>
     <name>Java Client</name>
-    <version>0.1.12</version>
+    <version>0.1.13</version>
     <url>https://github.com/hiddenlayerai/hiddenlayer-sdk-java</url>
     <description>Java SDK for HiddenLayer</description>
     <scm>
@@ -317,7 +317,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <jackson-version>2.18.2</jackson-version>
+        <jackson-version>2.17.0</jackson-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <junit-version>5.11.4</junit-version>

--- a/scanModel/pom.xml
+++ b/scanModel/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.hiddenlayer</groupId>
         <artifactId>java-client-parent</artifactId>
-        <version>0.1.12</version>
+        <version>0.1.13</version>
     </parent>
     <artifactId>scan-model</artifactId>
     <packaging>jar</packaging>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.hiddenlayer</groupId>
         <artifactId>java-client-parent</artifactId>
-        <version>0.1.12</version>
+        <version>0.1.13</version>
     </parent>
     <artifactId>hiddenlayer-sdk</artifactId>
     <packaging>jar</packaging>


### PR DESCRIPTION
## Describe your changes

In order to be compatible with the Jenkins plugin bundle at https://plugins.jenkins.io/jackson2-api we need to downgrade jackson to 2.17.0

