### PR TITLE
fix: fixes build errors due to OpenAPI elements that define the same enum wi…

### DIFF
--- a/hiddenlayer-java-core/src/main/kotlin/com/hiddenlayer/api/lib/ModelScanner.kt
+++ b/hiddenlayer-java-core/src/main/kotlin/com/hiddenlayer/api/lib/ModelScanner.kt
@@ -92,10 +92,7 @@ class ModelScanner(private val client: HiddenLayerClient) {
                 .build()
 
         val uploadStart = client.scans().upload().start(uploadStartParams)
-        val scanId: String =
-            uploadStart.scanId().orElseThrow {
-                RuntimeException("Upload start did not return scan ID")
-            }
+        val scanId: String = uploadStart.scanId()
 
         try {
             // Upload the file
@@ -190,10 +187,7 @@ class ModelScanner(private val client: HiddenLayerClient) {
                 .build()
 
         val uploadStart = client.scans().upload().start(uploadStartParams)
-        val scanId: String =
-            uploadStart.scanId().orElseThrow {
-                RuntimeException("Upload start did not return scan ID")
-            }
+        val scanId: String = uploadStart.scanId()
 
         try {
             // Upload each file
@@ -440,10 +434,7 @@ class AsyncModelScanner(private val client: HiddenLayerClientAsync) : AutoClosea
                         .build()
 
                 client.scans().upload().start(uploadStartParams).thenCompose { uploadStart ->
-                    val scanId: String =
-                        uploadStart.scanId().orElseThrow {
-                            RuntimeException("Upload start did not return scan ID")
-                        }
+                    val scanId: String = uploadStart.scanId()
 
                     // Upload the file async
                     uploadFileAsync(scanId, file.toPath()).thenCompose {
@@ -554,10 +545,7 @@ class AsyncModelScanner(private val client: HiddenLayerClientAsync) : AutoClosea
                         .build()
 
                 client.scans().upload().start(uploadStartParams).thenCompose { uploadStart ->
-                    val scanId: String =
-                        uploadStart.scanId().orElseThrow {
-                            RuntimeException("Upload start did not return scan ID")
-                        }
+                    val scanId: String = uploadStart.scanId()
 
                     // Upload each file async
                     val uploadFutures = files.map { file -> uploadFileAsync(scanId, file) }

--- a/hiddenlayer-java-core/src/main/kotlin/com/hiddenlayer/api/models/models/cards/CardListParams.kt
+++ b/hiddenlayer-java-core/src/main/kotlin/com/hiddenlayer/api/models/models/cards/CardListParams.kt
@@ -963,8 +963,6 @@ private constructor(
 
             @JvmField val SUSPICIOUS = of("SUSPICIOUS")
 
-            @JvmField val UNKNOWN = of("UNKNOWN")
-
             @JvmField val ERROR = of("ERROR")
 
             @JvmField val CRITICAL = of("critical")
@@ -987,7 +985,6 @@ private constructor(
             SAFE,
             UNSAFE,
             SUSPICIOUS,
-            UNKNOWN,
             ERROR,
             CRITICAL,
             HIGH,
@@ -1010,7 +1007,6 @@ private constructor(
             SAFE,
             UNSAFE,
             SUSPICIOUS,
-            UNKNOWN,
             ERROR,
             CRITICAL,
             HIGH,
@@ -1037,7 +1033,6 @@ private constructor(
                 SAFE -> Value.SAFE
                 UNSAFE -> Value.UNSAFE
                 SUSPICIOUS -> Value.SUSPICIOUS
-                UNKNOWN -> Value.UNKNOWN
                 ERROR -> Value.ERROR
                 CRITICAL -> Value.CRITICAL
                 HIGH -> Value.HIGH
@@ -1062,7 +1057,6 @@ private constructor(
                 SAFE -> Known.SAFE
                 UNSAFE -> Known.UNSAFE
                 SUSPICIOUS -> Known.SUSPICIOUS
-                UNKNOWN -> Known.UNKNOWN
                 ERROR -> Known.ERROR
                 CRITICAL -> Known.CRITICAL
                 HIGH -> Known.HIGH

--- a/hiddenlayer-java-core/src/test/kotlin/com/hiddenlayer/api/models/models/cards/CardListParamsTest.kt
+++ b/hiddenlayer-java-core/src/test/kotlin/com/hiddenlayer/api/models/models/cards/CardListParamsTest.kt
@@ -112,7 +112,7 @@ internal class CardListParamsTest {
                     .put("model_name[eq]", "eq")
                     .put(
                         "modscan_severity",
-                        listOf("ModscanSeverity{modelCardScanSafeUnsafe=SAFE}").joinToString(","),
+                        listOf("SAFE").joinToString(","),
                     )
                     .put("modscan_status", "ENABLED")
                     .put("offset", "250")

--- a/hiddenlayer-java-core/src/test/kotlin/com/hiddenlayer/api/models/models/cards/CardListParamsTest.kt
+++ b/hiddenlayer-java-core/src/test/kotlin/com/hiddenlayer/api/models/models/cards/CardListParamsTest.kt
@@ -110,10 +110,7 @@ internal class CardListParamsTest {
                     .put("model_created[lte]", "2019-12-27T18:11:19.117Z")
                     .put("model_name[contains]", "contains")
                     .put("model_name[eq]", "eq")
-                    .put(
-                        "modscan_severity",
-                        listOf("SAFE").joinToString(","),
-                    )
+                    .put("modscan_severity", listOf("SAFE").joinToString(","))
                     .put("modscan_status", "ENABLED")
                     .put("offset", "250")
                     .put("provider", listOf("AZURE").joinToString(","))


### PR DESCRIPTION
The OpenAPI spec for the model card v4 endpoint accepts 2 possible components:
Each component defines UNKNOWN, but uses different casing resulting in conflicting definitions.
This PR fixes that.

The OpenAPI spec getting a scan ID now reports that this property is required.  This leads to a change where our calls to `orElseThrow` are no longer valid.
This PR fixes that.