### PR TITLE
feat: add beta instability warnings for unstable SDK methods

### DIFF
--- a/.github/workflows/patch-beta-warnings.yml
+++ b/.github/workflows/patch-beta-warnings.yml
@@ -1,0 +1,34 @@
+name: Patch Beta Warnings
+
+on:
+  push:
+    branches:
+      - next
+
+jobs:
+  patch:
+    timeout-minutes: 5
+    name: patch-beta-warnings
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run beta warning patcher
+        run: node scripts/patch-beta-warnings.cjs
+
+      - name: Commit changes
+        run: |
+          git diff --quiet && exit 0
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "chore: patch beta warnings [skip ci]"
+          git push

--- a/hiddenlayer-java-core/src/main/kotlin/com/hiddenlayer/api/lib/BetaApi.kt
+++ b/hiddenlayer-java-core/src/main/kotlin/com/hiddenlayer/api/lib/BetaApi.kt
@@ -4,8 +4,8 @@ package com.hiddenlayer.api.lib
  * Marks an API as beta. Beta APIs are not GA or production ready and are subject to breaking
  * changes at any time.
  *
- * Kotlin consumers will see a compile-time warning when calling beta methods unless they
- * explicitly opt in with `@OptIn(BetaApi::class)`.
+ * Kotlin consumers will see a compile-time warning when calling beta methods unless they explicitly
+ * opt in with `@OptIn(BetaApi::class)`.
  */
 @RequiresOptIn(
     message = "This API is beta and subject to breaking changes at any time.",

--- a/hiddenlayer-java-core/src/main/kotlin/com/hiddenlayer/api/lib/BetaApi.kt
+++ b/hiddenlayer-java-core/src/main/kotlin/com/hiddenlayer/api/lib/BetaApi.kt
@@ -1,0 +1,16 @@
+package com.hiddenlayer.api.lib
+
+/**
+ * Marks an API as beta. Beta APIs are not GA or production ready and are subject to breaking
+ * changes at any time.
+ *
+ * Kotlin consumers will see a compile-time warning when calling beta methods unless they
+ * explicitly opt in with `@OptIn(BetaApi::class)`.
+ */
+@RequiresOptIn(
+    message = "This API is beta and subject to breaking changes at any time.",
+    level = RequiresOptIn.Level.WARNING,
+)
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
+annotation class BetaApi

--- a/hiddenlayer-java-core/src/main/kotlin/com/hiddenlayer/api/lib/BetaWarning.kt
+++ b/hiddenlayer-java-core/src/main/kotlin/com/hiddenlayer/api/lib/BetaWarning.kt
@@ -1,0 +1,32 @@
+package com.hiddenlayer.api.lib
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.logging.Logger
+
+/**
+ * Runtime beta warning utility.
+ *
+ * Emits a one-time warning per method name when a beta endpoint is called, so SDK consumers know
+ * the method is not yet GA.
+ */
+object BetaWarning {
+
+    private val logger = Logger.getLogger(BetaWarning::class.java.name)
+
+    private val warned: MutableSet<String> = ConcurrentHashMap.newKeySet()
+
+    /**
+     * Emit a one-time warning that a beta endpoint was called.
+     *
+     * @param qualifiedName Fully qualified method name, e.g. "JobService.request"
+     */
+    @JvmStatic
+    fun warnBeta(qualifiedName: String) {
+        if (warned.add(qualifiedName)) {
+            logger.warning(
+                "[BETA] $qualifiedName: This endpoint is not GA or Production ready and is" +
+                    " subject to changes at any time. Breaking changes may occur."
+            )
+        }
+    }
+}

--- a/hiddenlayer-java-core/src/test/kotlin/com/hiddenlayer/api/lib/BetaWarningTest.kt
+++ b/hiddenlayer-java-core/src/test/kotlin/com/hiddenlayer/api/lib/BetaWarningTest.kt
@@ -1,0 +1,75 @@
+package com.hiddenlayer.api.lib
+
+import java.util.Collections
+import java.util.logging.Handler
+import java.util.logging.LogRecord
+import java.util.logging.Logger
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class BetaWarningTest {
+
+    private val logRecords: MutableList<LogRecord> =
+        Collections.synchronizedList(mutableListOf<LogRecord>())
+
+    private val handler =
+        object : Handler() {
+            override fun publish(record: LogRecord) {
+                logRecords.add(record)
+            }
+
+            override fun flush() {}
+
+            override fun close() {}
+        }
+
+    private val logger = Logger.getLogger(BetaWarning::class.java.name)
+
+    @BeforeEach
+    fun setUp() {
+        logRecords.clear()
+        logger.addHandler(handler)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        logger.removeHandler(handler)
+        logRecords.clear()
+    }
+
+    @Test
+    fun warnBeta_emitsWarningOnFirstCall() {
+        BetaWarning.warnBeta("Test1.firstCall")
+
+        val relevant = logRecords.filter { it.message.contains("Test1.firstCall") }
+        assertThat(relevant).hasSize(1)
+        assertThat(relevant[0].message)
+            .isEqualTo(
+                "[BETA] Test1.firstCall: This endpoint is not GA or Production ready and is" +
+                    " subject to changes at any time. Breaking changes may occur."
+            )
+    }
+
+    @Test
+    fun warnBeta_doesNotEmitDuplicateWarnings() {
+        BetaWarning.warnBeta("Test2.dedup")
+        BetaWarning.warnBeta("Test2.dedup")
+        BetaWarning.warnBeta("Test2.dedup")
+
+        val relevant = logRecords.filter { it.message.contains("Test2.dedup") }
+        assertThat(relevant).hasSize(1)
+    }
+
+    @Test
+    fun warnBeta_emitsSeparateWarningsForDifferentMethods() {
+        BetaWarning.warnBeta("Test3.alpha")
+        BetaWarning.warnBeta("Test3.bravo")
+
+        val alpha = logRecords.filter { it.message.contains("Test3.alpha") }
+        val bravo = logRecords.filter { it.message.contains("Test3.bravo") }
+        assertThat(alpha).hasSize(1)
+        assertThat(bravo).hasSize(1)
+    }
+}

--- a/scripts/patch-beta-warnings.cjs
+++ b/scripts/patch-beta-warnings.cjs
@@ -1,0 +1,333 @@
+// @ts-check
+const fs = require('fs');
+const path = require('path');
+
+const coreDir = path.resolve(
+  __dirname,
+  '..',
+  'hiddenlayer-java-core',
+  'src',
+  'main',
+  'kotlin',
+  'com',
+  'hiddenlayer',
+  'api',
+);
+const servicesDir = path.join(coreDir, 'services');
+
+/**
+ * Recursively walk a directory yielding file paths.
+ */
+async function* walk(dir) {
+  for await (const d of await fs.promises.opendir(dir)) {
+    const entry = path.join(dir, d.name);
+    if (d.isDirectory()) yield* walk(entry);
+    else if (d.isFile()) yield entry;
+  }
+}
+
+/**
+ * Extract the interface/class name from a Kotlin service file.
+ * Matches: "interface FooService" or "class FooServiceImpl"
+ */
+function extractTypeName(content) {
+  const match = content.match(/(?:interface|class)\s+(\w+Service\w*)/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Scan an interface file for methods whose KDoc contains [BETA].
+ * Returns a Set of method names that are beta.
+ *
+ * KDoc pattern: /** [BETA] ... * / followed by fun methodName(
+ * Overloads use /** @see methodName * / — we track these too.
+ */
+function findBetaMethods(content) {
+  const betaMethods = new Set();
+
+  // Find methods with [BETA] in their KDoc
+  const kdocMethodPattern = /(\/\*\*[\s\S]*?\*\/)\s+(?:@\w+\s+)*fun\s+(\w+)\s*\(/g;
+  let match;
+  while ((match = kdocMethodPattern.exec(content)) !== null) {
+    const kdoc = match[1];
+    const methodName = match[2];
+    if (kdoc.includes('[BETA]')) {
+      betaMethods.add(methodName);
+    }
+  }
+
+  return betaMethods;
+}
+
+// ─── Interface patching ───────────────────────────────────────────────
+
+/**
+ * Patch an interface file: add @BetaApi annotation to beta methods and their
+ * @see overloads.
+ */
+function patchInterface(content, betaMethods) {
+  if (betaMethods.size === 0) return null;
+
+  const edits = [];
+
+  // Find all method declarations (with optional annotations before them)
+  // Pattern: optional KDoc, optional annotations, fun methodName(
+  const methodDeclPattern =
+    /(\/\*\*[\s\S]*?\*\/)\s+((?:@\w+(?:\([^)]*\))?\s+)*)fun\s+(\w+)\s*\(/g;
+  let match;
+  while ((match = methodDeclPattern.exec(content)) !== null) {
+    const kdoc = match[1];
+    const annotations = match[2];
+    const methodName = match[3];
+
+    // Skip withRawResponse, withOptions, and non-API methods
+    if (methodName === 'withRawResponse' || methodName === 'withOptions') continue;
+
+    // Check if this method is beta (directly or via @see)
+    const isBetaDirect = kdoc.includes('[BETA]') && betaMethods.has(methodName);
+    const isBetaSee = kdoc.includes('@see') && isSeeRefToBeta(kdoc, betaMethods);
+
+    if ((isBetaDirect || isBetaSee) && !annotations.includes('@BetaApi')) {
+      // Insert @BetaApi before 'fun'
+      const funIndex = content.indexOf('fun ' + methodName, match.index + kdoc.length);
+      if (funIndex !== -1) {
+        // Find start of the line with 'fun'
+        const lineStart = content.lastIndexOf('\n', funIndex) + 1;
+        const indent = content.slice(lineStart, funIndex).match(/^(\s*)/)[1];
+        edits.push({
+          index: funIndex,
+          text: '@BetaApi\n' + indent,
+        });
+      }
+    }
+  }
+
+  if (edits.length === 0) return null;
+
+  // Apply edits bottom-up
+  edits.sort((a, b) => b.index - a.index);
+  let modified = content;
+  for (const edit of edits) {
+    modified = modified.slice(0, edit.index) + edit.text + modified.slice(edit.index);
+  }
+
+  // Manage import
+  modified = manageImport(modified, 'import com.hiddenlayer.api.lib.BetaApi');
+
+  return modified !== content ? modified : null;
+}
+
+/**
+ * Check if a @see KDoc refers to a beta method.
+ */
+function isSeeRefToBeta(kdoc, betaMethods) {
+  const seeMatch = kdoc.match(/@see\s+(\w+)/);
+  return seeMatch ? betaMethods.has(seeMatch[1]) : false;
+}
+
+// ─── Implementation patching ──────────────────────────────────────────
+
+/**
+ * Patch an impl file: add warnBeta() calls to overridden beta methods.
+ *
+ * Converts expression-body methods to block-body with warnBeta() as first statement.
+ */
+function patchImpl(content, betaMethods, serviceName) {
+  if (betaMethods.size === 0) return null;
+
+  const edits = [];
+
+  for (const methodName of betaMethods) {
+    const warnCall = `BetaWarning.warnBeta("${serviceName}.${methodName}")`;
+
+    // Skip if already patched
+    if (content.includes(warnCall)) continue;
+
+    // Find the override fun for this method (the core overload that delegates to withRawResponse).
+    // Pattern: "override fun methodName(...): ReturnType ="
+    // The expression body starts after "=" and may include a comment line.
+    const overridePattern = new RegExp(
+      `override\\s+fun\\s+${escapeRegExp(methodName)}\\s*\\([\\s\\S]*?\\):\\s*\\S+\\s*=\\s*\\n`,
+    );
+    const match = overridePattern.exec(content);
+    if (!match) continue;
+
+    // Only patch methods that delegate to withRawResponse
+    const afterMatch = content.slice(match.index + match[0].length, match.index + match[0].length + 200);
+    if (!afterMatch.includes('withRawResponse()')) continue;
+
+    // Find the "=" position
+    const eqIndex = content.lastIndexOf('=', match.index + match[0].length);
+    if (eqIndex === -1) continue;
+
+    // Find the end of the expression body
+    const afterEq = content.indexOf('\n', eqIndex);
+    const exprEnd = findExpressionEnd(content, afterEq + 1);
+
+    // Extract lines after "=" and split into comment lines vs code lines
+    const rawBody = content.slice(afterEq + 1, exprEnd);
+    const lines = rawBody.split('\n');
+    const commentLines = [];
+    const codeLines = [];
+    for (const line of lines) {
+      if (line.trim().startsWith('//')) {
+        commentLines.push(line);
+      } else if (line.trim() !== '') {
+        codeLines.push(line);
+      }
+    }
+
+    // Build the replacement block body
+    const lineStart = content.lastIndexOf('\n', match.index) + 1;
+    const baseIndent = content.slice(lineStart, match.index).match(/^(\s*)/)[1];
+    const bodyIndent = baseIndent + '    ';
+
+    let newBody = ' {\n';
+    newBody += bodyIndent + warnCall + '\n';
+    for (const cl of commentLines) {
+      newBody += cl + '\n';
+    }
+    newBody += bodyIndent + 'return ' + codeLines.join('\n').trim() + '\n';
+    newBody += baseIndent + '}';
+
+    edits.push({
+      start: eqIndex,
+      end: exprEnd,
+      text: newBody,
+    });
+  }
+
+  if (edits.length === 0) return null;
+
+  // Apply edits bottom-up
+  edits.sort((a, b) => b.start - a.start);
+  let modified = content;
+  for (const edit of edits) {
+    modified = modified.slice(0, edit.start) + edit.text + modified.slice(edit.end);
+  }
+
+  // Manage import
+  modified = manageImport(modified, 'import com.hiddenlayer.api.lib.BetaWarning');
+
+  return modified !== content ? modified : null;
+}
+
+/**
+ * Find the end of an expression body starting from the given index.
+ * Expression bodies end when we hit a blank line, or a line starting with
+ * "override", "class", "private", or "}" at the member indent level.
+ */
+function findExpressionEnd(content, startIndex) {
+  let i = startIndex;
+  while (i < content.length) {
+    const lineEnd = content.indexOf('\n', i);
+    if (lineEnd === -1) return content.length;
+
+    const nextLineStart = lineEnd + 1;
+    const nextLine = content.slice(
+      nextLineStart,
+      content.indexOf('\n', nextLineStart),
+    );
+    const trimmed = nextLine.trim();
+
+    // Blank line or new member declaration signals end of expression
+    if (
+      trimmed === '' ||
+      trimmed.startsWith('override ') ||
+      trimmed.startsWith('class ') ||
+      trimmed.startsWith('private ') ||
+      trimmed.startsWith('internal ') ||
+      trimmed === '}'
+    ) {
+      return lineEnd;
+    }
+
+    i = lineEnd + 1;
+  }
+  return content.length;
+}
+
+// ─── Import management ────────────────────────────────────────────────
+
+function manageImport(content, importStatement) {
+  if (content.includes(importStatement)) return content;
+
+  // Find last import line
+  const importPattern = /^import\s.+$/gm;
+  let lastIndex = -1;
+  let m;
+  while ((m = importPattern.exec(content)) !== null) {
+    lastIndex = m.index + m[0].length;
+  }
+
+  if (lastIndex !== -1) {
+    return (
+      content.slice(0, lastIndex) +
+      '\n' +
+      importStatement +
+      content.slice(lastIndex)
+    );
+  }
+  return content;
+}
+
+function escapeRegExp(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────
+
+async function main() {
+  let patchedCount = 0;
+
+  for await (const filePath of walk(servicesDir)) {
+    if (!filePath.endsWith('.kt')) continue;
+
+    // Only process interface files (not Impl files)
+    const basename = path.basename(filePath, '.kt');
+    if (basename.endsWith('Impl')) continue;
+    if (!basename.endsWith('Service') && !basename.endsWith('ServiceAsync'))
+      continue;
+
+    const content = await fs.promises.readFile(filePath, 'utf8');
+
+    // Must be an interface
+    if (!content.includes('interface ')) continue;
+
+    const typeName = extractTypeName(content);
+    if (!typeName) continue;
+
+    const betaMethods = findBetaMethods(content);
+
+    // Patch the interface file
+    const patchedInterface = patchInterface(content, betaMethods);
+    if (patchedInterface !== null) {
+      await fs.promises.writeFile(filePath, patchedInterface, 'utf8');
+      console.log(`patched ${path.relative(process.cwd(), filePath)}`);
+      patchedCount++;
+    }
+
+    // Patch the corresponding impl file
+    const implFileName = basename + 'Impl.kt';
+    const implPath = path.join(path.dirname(filePath), implFileName);
+    if (fs.existsSync(implPath)) {
+      const implContent = await fs.promises.readFile(implPath, 'utf8');
+
+      // Extract the service name (strip "Async" suffix for the warning)
+      const serviceName = typeName.replace(/Async$/, '');
+      const patchedImpl = patchImpl(implContent, betaMethods, serviceName);
+      if (patchedImpl !== null) {
+        await fs.promises.writeFile(implPath, patchedImpl, 'utf8');
+        console.log(`patched ${path.relative(process.cwd(), implPath)}`);
+        patchedCount++;
+      }
+    }
+  }
+
+  console.log(`\n${patchedCount} file(s) patched.`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Adds automatic compile-time and runtime warnings for beta SDK methods, mirroring the TypeScript SDK implementation.

## Changes
- `@BetaApi` annotation using Kotlin's `@RequiresOptIn` for compile-time warnings in Kotlin consumers
- `BetaWarning.warnBeta()` utility with thread-safe dedup for one-time runtime warnings via `java.util.logging`
- CI patcher script (`scripts/patch-beta-warnings.cjs`) that scans generated service files for `[BETA]` in KDoc and injects `@BetaApi` on interfaces and `warnBeta()` calls in implementations
- GitHub Actions workflow to run the patcher automatically on pushes to `next`
- Unit tests for the warning utility

## Related Issues
DIS-936

## Breaking Changes
None