### PR TITLE
fix(ci): run CI on all PRs, remove dead Stainless code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,7 @@ jobs:
   lint:
     timeout-minutes: 15
     name: lint
-    runs-on: ${{ github.repository == 'stainless-sdks/hiddenlayer-sdk-java' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
-    if: (github.event_name == 'push' || github.event.pull_request.head.repo.fork) && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -42,11 +41,7 @@ jobs:
   build:
     timeout-minutes: 15
     name: build
-    permissions:
-      contents: read
-      id-token: write
-    runs-on: ${{ github.repository == 'stainless-sdks/hiddenlayer-sdk-java' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
-    if: (github.event_name == 'push' || github.event.pull_request.head.repo.fork) && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -66,30 +61,11 @@ jobs:
       - name: Build SDK
         run: ./scripts/build
 
-      - name: Get GitHub OIDC Token
-        if: |-
-          github.repository == 'stainless-sdks/hiddenlayer-sdk-java' &&
-          !startsWith(github.ref, 'refs/heads/stl/')
-        id: github-oidc
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        with:
-          script: core.setOutput('github_token', await core.getIDToken());
-
-      - name: Build and upload Maven artifacts
-        if: |-
-          github.repository == 'stainless-sdks/hiddenlayer-sdk-java' &&
-          !startsWith(github.ref, 'refs/heads/stl/')
-        env:
-          URL: https://pkg.stainless.com/s
-          AUTH: ${{ steps.github-oidc.outputs.github_token }}
-          SHA: ${{ github.sha }}
-          PROJECT: hiddenlayer-sdk-java
-        run: ./scripts/upload-artifacts
   test:
     timeout-minutes: 15
     name: test
-    runs-on: ${{ github.repository == 'stainless-sdks/hiddenlayer-sdk-java' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
+    runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 


### PR DESCRIPTION
## Summary

- Remove the fork-only PR gate, codegen-metadata skip, stainless-sdks runner ternary, and OIDC upload steps
- CI now runs on all push and pull_request events
- Required for codegen PRs to satisfy the next ruleset's required checks before auto-merge

## Test plan

- [ ] CI runs on this PR (proves same-repo PR trigger works)
- [ ] CI still runs on push to next after merge